### PR TITLE
PL language added to app

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,7 +1,9 @@
 import enUS from "./en-us"
 import deDE from "./de"
+import plPL from "./pl"
 
 export default {
   "en-us": enUS,
   de: deDE,
+  pl: plPL,
 }

--- a/src/i18n/pl/index.js
+++ b/src/i18n/pl/index.js
@@ -1,0 +1,52 @@
+export default {
+  title: "Automa - Szarlatan z Pasikurowic",
+  variantby: "Aplikacja bazuje na nieoficjalnym wariancie solo stworzonym przez",
+  quacksby: 'dla gry "Szarlatani z Pasikurowic" autora',
+  implementedby: "Autor niniejszej aplikacji to",
+  selectlevel: "Wybierz poziom trudności",
+  vp: "Punkty zwycięstwa",
+  level: "Poziom",
+  droplet: "Kropelka",
+  ratstone: "Szczurze ogony",
+  addrattails: "Dodaj szczurze ogony jeżeli prowadzisz",
+  beatrival: "Czy pokonałeś przeciwnika?",
+  score: "Wynik",
+  round: "Runda",
+  newgame: "Nowa gra",
+  endgame: "Zakończ grę",
+  nextround: "Koniec rundy",
+  play: "Graj",
+  info: "Info",
+  github:
+    "Jest to projekt open source pod licencją MIT, który został opublikowany na GitHub",
+  solorules: "Zasady Solo",
+  setup: "Przygotowanie",
+  setupparagraph:
+    "Przygotuj grę jak dla dwóch graczy. Usuń z gry karty Wróżki ‘Radość’ i ‘Mniej znaczy więcej’. Następnie zdecyduj, jaki poziom trudności wybierasz: I, II, czy III (Suma punktów przeciwnika, którą musisz pobić aby wygrać, rośnie wraz z poziomem trudności.).",
+  howtoplay: "Jak grać solo, szczegółowy opis rundy:",
+  howtofortuneteller:
+    "Karty Wróżki działają normalnie, lecz Twój przeciwnik nie otrzymuje z nich żadnych benefitów.",
+  howtorattails:
+    "Szczurze ogony zdobywa się na tych samych zasadach. Jeśli prowadzisz, Twój przeciwnik otrzymuje szczurze ogony - dodaj je przesuwając suwak widoczny na ekranie o liczbę ogonów między Twoim znacznikiem, a znacznikiem przeciwnika. Pozwoli to na prawidłowe określenie jego pola punktującego.",
+  howtobrew:
+    "Warz swój eliksir jak w podstawowej grze. Wartości pola punktowego przeciwnika są pokazane w specjalnym miejscu.",
+  evaluationphase: "Faza ewaluacji",
+  evalbonusdie:
+    "Jeśli Twoje pole punktowe jest takie samo bądź dotarłeś dalej (i eliksir nie wybuchł), rzuć kością bonusową. Twój przeciwnik nigdy nie rzuca kością i nie otrzymuje bonusów.",
+  evalblackchips:
+    "Jeżeli w Twoim kociołku znajdują się czarne znaczniki, sprawdź, czy pod polem punktowym Twojego przeciwnika widoczne są jakieś czarne znaczniki. Jeśli w Twoim kociołku jest ich więcej, otrzymaj nagrodę zgodnie z zasadami. Twój przeciwnik nigdy nie otrzymuje nagrody za czarne składniki. Następnie sprawdź zielone oraz fioletowe znaczniki zgodnie z podstawowymi zasadami.",
+  evalrubies:
+    "Rubiny zdobywasz tak, jak w podstawowej grze. Twój przeciwnik również zdobywa rubiny - aplikacja zajmuje się tym automatycznie.",
+  evalscorepoints: "Zdobądź punkty za rundę - aplikacja automatycznie liczy ilość punktów Twojego przeciwnika.",
+  evalbuyingredients:
+    "Kupuj składniki zgodnie z podstawowymi zasadami. Twój przeciwnik rośnie w siłę automatycznie w trakcie trwania rozgrywki. W rundzie 9, zamiast zakupów, Twój przeciwnik automatycznie przeliczy wartość pola punktowego na punkty zwycięstwa (za każde 5 monet otrzyma 1 punkt zwycięstwa). Dokładnie tak samo przelicz swoje monety na punkty zwycięstwa w ostatniej rundzie.",
+  evalspendrubies:
+    "Wydawaj swoje rubiny zgodnie z podstawowymi zasadami. Twój przeciwnik automatycznie wyda rubiny, jeśli będzie to możliwe. To także wpłynie na jego wzmocnienie w kolejnych rundach. W rundzie 9, zamiast standardowej wymiany rubinów, Twój przeciwnik wyda każde pozostałe 2 rubiny na 1 punkt zwycięstwa (tak samo jak Ty w ostatniej rundzie).",
+  howtoresetratstone:
+    "Jeśli w Twoim kociołku znajdowały się szczurze ogony, wyciągnij znacznik z mikstury i połóż go na przeznaczonym dla niego polu na Twojej planszy gracza.",
+  howtoendround: 'Kliknij przycisk "Koniec rundy".',
+  endofgame: "Koniec gry",
+  howtoendgame:
+    'Po rozegraniu rundy 9, wciśnik przycisk "Koniec gry". Twój przeciwnik automatycznie przeliczy swoje ostatnie pole punktowe i zostanie wyświetlony jego ostateczny wynik.',
+  endresult: "Ostateczny wynik Twojego przeciwnika",
+}


### PR DESCRIPTION
- created new "pl" folder in "i18n" folder
- created new index.js within the pl flder with PL translation (basing on en-US file and Polish version of Quacks of Quedlinburg manual)
- modified index.js file to allow PL language to kick in if the user's browser language is set to PL

Since Polish name of the boardgame is translated to "Szarlatani z Pasikurowic" I've modified the app name to resemblance the Polish title - "Automa - Szarlatan z Pasikurowic". If you wish to stay with the original "The Rival Quack of Quedlinburg" just change it before merging 👍 